### PR TITLE
Fix level and maxExp issue

### DIFF
--- a/Server/Emulator/Database/types.cs
+++ b/Server/Emulator/Database/types.cs
@@ -87,7 +87,16 @@ public class types
         public string steamId;
         public uint level = 1;
         public uint curExp = 0;
-        public uint maxExp = 50;
+        public uint maxExp
+        {
+            get
+            {
+                if (level >= 30)
+                    return 0;
+                else
+                    return (uint)(50 * System.Math.Pow(1.2, level - 1));
+            }
+        }
         public uint selectCharId;
         public uint language = 2;
         public uint sessionId = 0;

--- a/Server/Emulator/Handlers/GateHandlers/Beatmaps.cs
+++ b/Server/Emulator/Handlers/GateHandlers/Beatmaps.cs
@@ -404,7 +404,6 @@ public static class Beatmaps
                         goldGained += (uint)Math.Floor(Math.Pow(account.level, 0.8)) * 60;
                     }
                     account.curExp -= account.maxExp;
-                    account.maxExp = (uint)Math.Round(account.maxExp * 1.2f, 0);
                 }
 
                 account.currencyInfo.diamond += goldGained;

--- a/Server/Emulator/Handlers/GateHandlers/CosmicTour.cs
+++ b/Server/Emulator/Handlers/GateHandlers/CosmicTour.cs
@@ -216,6 +216,11 @@ public static class CosmicTour
                         {
                             goldGained += (uint)Math.Floor(Math.Pow(account.level, 0.8)) * 60;
                         }
+                        if (account.level == 30)
+                        {
+                            account.curExp = 0;
+                            break;
+                        }
                         account.curExp -= account.maxExp;
                     }
                     account.currencyInfo.gold += goldGained;

--- a/Server/Emulator/Handlers/GateHandlers/CosmicTour.cs
+++ b/Server/Emulator/Handlers/GateHandlers/CosmicTour.cs
@@ -200,19 +200,26 @@ public static class CosmicTour
                     }
                 }
 
-                account.curExp += (uint)Math.Round(missionsCompleted * 10f);
-                uint goldGained = 0;
-                while (account.curExp >= account.maxExp)
+                if (account.level >= 30)
                 {
-                    account.level++;
-                    if (account.level % 5 == 0)
-                    {
-                        goldGained += (uint)Math.Floor(Math.Pow(account.level, 0.8)) * 60;
-                    }
-                    account.curExp -= account.maxExp;
-                    account.maxExp = (uint)Math.Round(account.maxExp * 1.2f, 0);
+                    account.level = 30;
+                    account.curExp = 0;
                 }
-                account.currencyInfo.gold += goldGained;
+                else
+                {
+                    account.curExp += (uint)Math.Round(missionsCompleted * 10f);
+                    uint goldGained = 0;
+                    while (account.curExp >= account.maxExp)
+                    {
+                        account.level++;
+                        if (account.level % 5 == 0)
+                        {
+                            goldGained += (uint)Math.Floor(Math.Pow(account.level, 0.8)) * 60;
+                        }
+                        account.curExp -= account.maxExp;
+                    }
+                    account.currencyInfo.gold += goldGained;
+                }
                 settleData.expData = new()
                 {
                     curExp = account.curExp,

--- a/Server/Emulator/Handlers/GateHandlers/Shop.cs
+++ b/Server/Emulator/Handlers/GateHandlers/Shop.cs
@@ -69,7 +69,6 @@ public static class Shop
                             {
                                 account.curExp -= account.maxExp;
                                 account.level++;
-                                account.maxExp = (uint)Math.Round(account.maxExp * 1.2f, 0);
                             }
 
                             Server.Database.UpdateAccount(account);
@@ -134,7 +133,6 @@ public static class Shop
                             {
                                 account.curExp -= account.maxExp;
                                 account.level++;
-                                account.maxExp = (uint)Math.Round(account.maxExp * 1.2f, 0);
                             }
 
                             Server.Database.UpdateAccount(account);
@@ -187,7 +185,6 @@ public static class Shop
                             {
                                 account.curExp -= account.maxExp;
                                 account.level++;
-                                account.maxExp = (uint)Math.Round(account.maxExp * 1.2f, 0);
                             }
 
                             Server.Database.UpdateAccount(account);


### PR DESCRIPTION
the max level of this game is 30. when your reach this level, the curExp and maxExp should be 0. and also, maxExp constitute an arithmetic sequence(a1=50, q=1.2), it should only depends on the level. so we don't need to calculate it through previous maxExp.  
for now, if I set curExp and maxExp to 0 in the registry, when I finish cosmic tour, the game will get stuck.  
this patch fixes the above issues.