### PR TITLE
Fix SP1 issue

### DIFF
--- a/Server/Emulator/Database/db.cs
+++ b/Server/Emulator/Database/db.cs
@@ -93,6 +93,21 @@ public class Database
                 storyData.missionList.AddRange(missions);
             }
 
+            account.cosmicTourData.specialStoryData = JsonMapper.ToObject<List<cometScene.SpecialStoryData>>(acc["cosmicTourData"]["specialStoryData"].ToJson());
+            for (var i = 0; i < account.cosmicTourData.specialStoryData.Count; i++)
+            {
+                for (var k = 0; k < account.cosmicTourData.specialStoryData[k].list.Count; k++)
+                {
+                    account.cosmicTourData.specialStoryData[i].list[k].missionList.AddRange(JsonMapper.ToObject<List<uint>>(acc["cosmicTourData"]["specialStoryData"][i]["list"][k]["missionList"].ToJson()));
+                }
+                foreach (var storyData in account.cosmicTourData.specialStoryData[i].list)
+                {
+                    var missions = storyData.missionList.ToList().Distinct();
+                    storyData.missionList.RemoveAll(e => true);
+                    storyData.missionList.AddRange(missions);
+                }
+            }
+
             Accounts[account.accId] = account;
         }
     }

--- a/Server/Emulator/Database/db.cs
+++ b/Server/Emulator/Database/db.cs
@@ -81,31 +81,46 @@ public class Database
             account.songList.list.AddRange(JsonMapper.ToObject<List<cometScene.SongData>>(acc["songList"]["list"].ToJson()));
             account.songList.favoriteList.AddRange(JsonMapper.ToObject<List<uint>>(acc["songList"]["favoriteList"].ToJson()));
             // ===========Cosmic Tour============
-            account.cosmicTourData.storyData = JsonMapper.ToObject<List<cometScene.StoryData>>(acc["cosmicTourData"]["storyData"].ToJson());
-            for (var i = 0; i < account.cosmicTourData.storyData.Count; i++)
+            try
             {
-                account.cosmicTourData.storyData[i].missionList.AddRange(JsonMapper.ToObject<List<uint>>(acc["cosmicTourData"]["storyData"][i]["missionList"].ToJson()));
-            }
-            foreach (var storyData in account.cosmicTourData.storyData)
-            {
-                var missions = storyData.missionList.ToList().Distinct();
-                storyData.missionList.RemoveAll(e => true);
-                storyData.missionList.AddRange(missions);
-            }
-
-            account.cosmicTourData.specialStoryData = JsonMapper.ToObject<List<cometScene.SpecialStoryData>>(acc["cosmicTourData"]["specialStoryData"].ToJson());
-            for (var i = 0; i < account.cosmicTourData.specialStoryData.Count; i++)
-            {
-                for (var k = 0; k < account.cosmicTourData.specialStoryData[k].list.Count; k++)
+                account.cosmicTourData.storyData = JsonMapper.ToObject<List<cometScene.StoryData>>(acc["cosmicTourData"]["storyData"].ToJson());
+                for (var i = 0; i < account.cosmicTourData.storyData.Count; i++)
                 {
-                    account.cosmicTourData.specialStoryData[i].list[k].missionList.AddRange(JsonMapper.ToObject<List<uint>>(acc["cosmicTourData"]["specialStoryData"][i]["list"][k]["missionList"].ToJson()));
+                    account.cosmicTourData.storyData[i].missionList.AddRange(JsonMapper.ToObject<List<uint>>(acc["cosmicTourData"]["storyData"][i]["missionList"].ToJson()));
                 }
-                foreach (var storyData in account.cosmicTourData.specialStoryData[i].list)
+                foreach (var storyData in account.cosmicTourData.storyData)
                 {
                     var missions = storyData.missionList.ToList().Distinct();
                     storyData.missionList.RemoveAll(e => true);
                     storyData.missionList.AddRange(missions);
                 }
+            }
+            catch (Exception)
+            {
+                account.cosmicTourData.storyData = new();
+            }
+
+            try
+            {
+                account.cosmicTourData.specialStoryData = JsonMapper.ToObject<List<cometScene.SpecialStoryData>>(acc["cosmicTourData"]["specialStoryData"].ToJson());
+                for (var i = 0; i < account.cosmicTourData.specialStoryData.Count; i++)
+                {
+                    account.cosmicTourData.specialStoryData[i].list.AddRange(JsonMapper.ToObject<List<cometScene.StoryData>>(acc["cosmicTourData"]["specialStoryData"][i]["list"].ToJson()));
+                    for (var k = 0; k < account.cosmicTourData.specialStoryData[i].list.Count; k++)
+                    {
+                        account.cosmicTourData.specialStoryData[i].list[k].missionList.AddRange(JsonMapper.ToObject<List<uint>>(acc["cosmicTourData"]["specialStoryData"][i]["list"][k]["missionList"].ToJson()));
+                    }
+                    foreach (var storyData in account.cosmicTourData.specialStoryData[i].list)
+                    {
+                        var missions = storyData.missionList.ToList().Distinct();
+                        storyData.missionList.RemoveAll(e => true);
+                        storyData.missionList.AddRange(missions);
+                    }
+                }
+            }
+            catch (Exception)
+            {
+                account.cosmicTourData.specialStoryData = new();
             }
 
             Accounts[account.accId] = account;

--- a/Server/Emulator/Database/types.cs
+++ b/Server/Emulator/Database/types.cs
@@ -9,7 +9,7 @@ public class types
     {
         private List<Aquatrax.StoryPlannetData> _planetData;
 
-        public const uint DlcStart = 100;
+        public static uint DlcStart = 100;
 
         private uint latestChapterId = 1;
         private uint latestLevelId = 1;
@@ -26,7 +26,7 @@ public class types
                 try { latestChapterId = storyData.Max(story => story.chapterId); }
                 catch (System.ArgumentNullException) { }
 
-                try { latestLevelId = storyData.Max(level => level.levelId); }
+                try { latestLevelId = storyData.Where(story => story.chapterId == latestChapterId).Max(level => level.levelId); }
                 catch (System.ArgumentNullException) { }
 
                 var chapter = _planetData.First(planet => planet.Id == latestChapterId);
@@ -55,7 +55,7 @@ public class types
                 try { latestSpecialChapterId = specialStoryData.Max(story => story.chapterId); }
                 catch (System.ArgumentNullException) { }
 
-                try { latestSpecialLevelId = specialStoryData.Max(level => level.curLevelId); }
+                try { latestSpecialLevelId = specialStoryData.Where(story => story.chapterId == latestSpecialChapterId).Max(level => level.curLevelId); }
                 catch (System.ArgumentNullException) { }
 
                 var spec_chapter = _planetData.First(planet => planet.Id == latestSpecialChapterId);

--- a/Server/Emulator/Database/types.cs
+++ b/Server/Emulator/Database/types.cs
@@ -7,8 +7,15 @@ public class types
 {
     public class CosmicTourData
     {
-        private List<uint> _currentData;
         private List<Aquatrax.StoryPlannetData> _planetData;
+
+        public const uint DlcStart = 100;
+
+        private uint latestChapterId = 1;
+        private uint latestLevelId = 1;
+
+        private uint latestSpecialChapterId = DlcStart;
+        private uint latestSpecialLevelId = 1;
 
         private void Init()
         {
@@ -16,14 +23,10 @@ public class types
 
             if (storyData.Count != 0)
             {
-                uint latestChapterId = 1;
-                uint latestLevelId = 1;
-
-
                 try { latestChapterId = storyData.Max(story => story.chapterId); }
                 catch (System.ArgumentNullException) { }
 
-                try { latestLevelId = storyData.Where(story => story.chapterId == latestChapterId).Max(level => level.levelId); }
+                try { latestLevelId = storyData.Max(level => level.levelId); }
                 catch (System.ArgumentNullException) { }
 
                 var chapter = _planetData.First(planet => planet.Id == latestChapterId);
@@ -45,36 +48,65 @@ public class types
                 {
                     latestLevelId++;
                 }
-
-                _currentData = new() { latestChapterId, latestLevelId, latestChapterId, latestLevelId };
             }
-            else _currentData = new() { 1, 1, 1, 1 };
+
+            if (specialStoryData.Count != 0)
+            {
+                try { latestSpecialChapterId = specialStoryData.Max(story => story.chapterId); }
+                catch (System.ArgumentNullException) { }
+
+                try { latestSpecialLevelId = specialStoryData.Max(level => level.curLevelId); }
+                catch (System.ArgumentNullException) { }
+
+                var spec_chapter = _planetData.First(planet => planet.Id == latestSpecialChapterId);
+                var spec_level = spec_chapter.Levels.First(level => level.Sequence == latestSpecialLevelId);
+
+                if (spec_chapter.Levels.IndexOf(spec_level) == spec_chapter.Levels.Count - 1)
+                {
+                    foreach (var planet in _planetData)
+                    {
+                        if ((planet.Id - 1) == latestSpecialChapterId)
+                        {
+                            latestSpecialChapterId = (uint)planet.Id;
+                            latestSpecialLevelId = (uint)planet.Levels[0].Sequence;
+                            break;
+                        }
+                    }
+                }
+                else
+                {
+                    latestSpecialLevelId++;
+                }
+            }
         }
 
-        public uint GetCurNormalChapterId()
+        public void ApplyToStoryInfo(ref cometScene.Ret_Story_Info info)
         {
             Init();
-            return _currentData[0];
+            info.curNormalChapterId = latestChapterId;
+            info.curNormalLevelId = latestLevelId;
+            info.curTutorialChapterId = latestChapterId;
+            info.curTutorialLevelId = latestLevelId;
+
+            var specList = new cometScene.SpecialStoryData();
+            specList.chapterId = latestSpecialChapterId;
+            specList.curLevelId = latestSpecialLevelId;
+            info.specialList.Add(specList);
         }
 
-        public uint GetCurNormalLevelId()
+        public void ApplyToStoryFinish(ref cometScene.Ret_Story_Finish info)
         {
             Init();
-            return _currentData[1];
-        }
-
-        public uint GetCurTutorialChapterId()
-        {
-            Init();
-            return _currentData[2];
-        }
-        public uint GetCurTutorialLevelId()
-        {
-            Init();
-            return _currentData[3];
+            info.curNormalChapterId = latestChapterId;
+            info.curNormalLevelId = latestLevelId;
+            info.curTutorialChapterId = latestChapterId;
+            info.curTutorialLevelId = latestLevelId;
+            info.curSpecialChapterId = latestSpecialChapterId;
+            info.curSpecialLevelId = latestSpecialLevelId;
         }
 
         public List<cometScene.StoryData> storyData = new() { };
+        public List<cometScene.SpecialStoryData> specialStoryData = new() { };
     }
 
     public class AccountData

--- a/Server/Emulator/Handlers/GateHandlers/CosmicTour.cs
+++ b/Server/Emulator/Handlers/GateHandlers/CosmicTour.cs
@@ -155,6 +155,7 @@ public static class CosmicTour
                     };
                     if (chapter.Id >= types.CosmicTourData.DlcStart)
                     {
+                        account.cosmicTourData.specialStoryData.RemoveAll(story => story.chapterId == chapter.Id && story.curLevelId == level.Sequence);
                         var specialStoryData = new cometScene.SpecialStoryData();
                         specialStoryData.chapterId = (uint)chapter.Id;
                         specialStoryData.curLevelId = (uint)level.Sequence;
@@ -163,6 +164,7 @@ public static class CosmicTour
                     }
                     else
                     {
+                        account.cosmicTourData.storyData.RemoveAll(story => story.chapterId == chapter.Id && story.levelId == level.Sequence);
                         account.cosmicTourData.storyData.Add(storyData);
                     }
                 }


### PR DESCRIPTION
1. play SP1(aka. 2:3) will unlock all other chapter due to SP1's chapter id is 100. this is not a normal chapter id that should not store in storyData, it should be store in specialStoryData.  
2. when I complete level 1 in SP1, the other levels will not be unlocked.  

this patch fixes the above issues.
but this patch did not fixes missionList in SP1, I'll try to fix it when I am free, but I don't really have so much free time for this. so if someone can fix this, just go ahead.